### PR TITLE
#1 adjust size of cards

### DIFF
--- a/components/index/ProjectCard.vue
+++ b/components/index/ProjectCard.vue
@@ -39,6 +39,6 @@
   object-fit:cover;
 }
 .card-body{
-  height:300px;
+  height:200px;
 }
 </style>

--- a/components/index/ProjectCard.vue
+++ b/components/index/ProjectCard.vue
@@ -34,5 +34,11 @@
 </script>
 
 <style scoped>
-
+.card-img-top{
+  height:200px;
+  object-fit:cover;
+}
+.card-body{
+  height:300px;
+}
 </style>


### PR DESCRIPTION
対応Issue
https://github.com/codeforyouth/CACTUS-Client/issues/1

変更点
- カードの写真とBodyの高さを `px` で明示的に指定
- 画像は真ん中を中心にトリミング

<img width="1218" alt="スクリーンショット 2019-10-19 01 16 11" src="https://user-images.githubusercontent.com/19162252/67110680-40ac2c00-f20e-11e9-99a4-33e57aadd260.png">
